### PR TITLE
Declare module "obsidian" and fix small errors

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -5,7 +5,28 @@ interface BibleReferencesSettings {
   customLinkScheme: string;
 }
 
-let fixBibleReferences = function(plugin) {
+declare module "obsidian" {
+  interface App {
+    plugins: {
+      plugins: {
+        dataview: {
+          index: {
+            tags: {
+              invMap: Map<string, Set<string>>;
+              map: Map<string, Set<string>>;
+            };
+            etags: {
+              invMap: Map<string, Set<string>>;
+              map: Map<string, Set<string>>;
+            };
+          };
+        };
+      };
+    };
+  }
+}
+
+let fixBibleReferences = function(plugin: any) {
   let BOOKS:any = {
     'Genesis': /Genesis|Gen\.?|Ge\.?|Gn\.?/,
     'Exodus': /Exodus|Ex\.?|Exod\.?|Exo\.?/,
@@ -122,7 +143,7 @@ let fixBibleReferences = function(plugin) {
       content = content.replace(str, wikiBible(ref))
     }
   }
-  globalThis.app.vault.modify(view.file, content);
+  this.plugin.app.vault.modify(view.file, content);
 }
 
 const DEFAULT_SETTINGS: BibleReferencesSettings = {

--- a/main.ts
+++ b/main.ts
@@ -197,4 +197,4 @@ class SampleSettingTab extends PluginSettingTab {
       }
     );
   }
-
+}

--- a/main.ts
+++ b/main.ts
@@ -143,7 +143,7 @@ let fixBibleReferences = function(plugin: any) {
       content = content.replace(str, wikiBible(ref))
     }
   }
-  this.plugin.app.vault.modify(view.file, content);
+  plugin.app.vault.modify(view.file, content);
 }
 
 const DEFAULT_SETTINGS: BibleReferencesSettings = {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
+    "@types/mustache": "^4.1.2",
     "@types/node": "^14.17.3",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "rollup": "^2.52.2",


### PR DESCRIPTION
Hi!

This pull requests fixes #9 referencing the 'obsidian' module. (a solution I found in [valentine195/obsidian-dice-roller](https://github.com/valentine195/obsidian-dice-roller/blob/115a505854636a19f901a8c4f39fe8bbb6a9b796/src/main.ts#L40)).

I also resolved smaller things that threw errors on my side:
* Added a missing `}`
* Added `mustache` in `package.json`
* Resolve index signature error of "globalThis" by referencing `plugin` instead

Note: I pulled from `settings-page`, so my pull request #10 is not included here (keeping things nice and atomic). If expanding the settings is something that we need, we can add it later.